### PR TITLE
Lab2 fix

### DIFF
--- a/lab-2/website/index.html
+++ b/lab-2/website/index.html
@@ -76,7 +76,7 @@
     <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
 
     <script src="js/vendor/bootstrap.min.js"></script>
-    <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>
+    <script src="https://cdn.auth0.com/js/lock/11.15.0/lock.min.js"></script>
 
     <script src="js/user-controller.js"></script>
     <script src="js/config.js"></script>

--- a/lab-2/website/package.json
+++ b/lab-2/website/package.json
@@ -2,17 +2,17 @@
   "name": "24-hour-video",
   "version": "1.0.0",
   "description": "The 24 Hour Video Website",
-  "local-web-server": {
-  	"port": 8100,
-  	"forbid": "*.json"
+  "lws": {
+    "port": 8100,
+    "forbid": "*.json"
   },
   "scripts": {
-  	"start": "ws",
+    "start": "ws -p $npm_package_lws_port",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Peter Sbarski",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "local-web-server": "^1.1.0"
+    "local-web-server": "^2.6.1"
   }
 }


### PR DESCRIPTION
I believe this will fix the issue that doesn't allow users to sign up/log in to website using Auth0.

Figured it wouldn't hurt to update the Auth0 lock library.

When running `npm install`, was getting warnings about vulnerabilities. So updated local-web-server to current version 2.6.1. After that update was done, it defaulted to port 8000 and wasn't using the variable defined as 8100. So instead of Julian needing to re-record the lectures over to use port 8000, I changed variable `local-web-server` to `lws` because the hyphens weren't usable in the npm_package variable.