### PR TITLE
update JQuery to prevent CORS issue

### DIFF
--- a/lab-2/website/index.html
+++ b/lab-2/website/index.html
@@ -73,8 +73,8 @@
         </div>
     </div>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
 
     <script src="js/vendor/bootstrap.min.js"></script>
     <script src="https://cdn.auth0.com/js/lock/11.16.0/lock.min.js"></script>

--- a/lab-3/website/index.html
+++ b/lab-3/website/index.html
@@ -98,8 +98,8 @@
     <!-- /.modal -->
     <!-- User profile modal -->
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
 
     <script src="js/vendor/bootstrap.min.js"></script>
     <script src="https://cdn.auth0.com/js/lock/11.16.0/lock.min.js"></script>

--- a/lab-4/website/index.html
+++ b/lab-4/website/index.html
@@ -117,8 +117,8 @@
     <!-- /.modal -->
     <!-- User profile modal -->
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
 
     <script src="js/vendor/bootstrap.min.js"></script>
     <script src="https://cdn.auth0.com/js/lock/11.16.0/lock.min.js"></script>

--- a/lab-5/website/index.html
+++ b/lab-5/website/index.html
@@ -140,8 +140,8 @@
     <!-- /.modal -->
     <!-- User profile modal -->
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.4.1.min.js"><\/script>')</script>
 
     <script src="js/vendor/bootstrap.min.js"></script>
     <script src="https://cdn.auth0.com/js/lock/11.16.0/lock.min.js"></script>


### PR DESCRIPTION
'elo Cloud Gurus! I hit a snag in the serverless workshop with CORS blocking me in Lab 2. The issue is with the `x-requested-with` header field; here is the CORS error from the console:

> CORS policy: Request header field x-requested-with is not allowed by Access-Control-Allow-Headers in preflight response.

I found this discussed here:

https://acloud.guru/forums/serverless-for-beginners/discussion/-L_lzhGqtheBLRwD-fd8/request_header_field_x-request

There was a solid work-around that could be added to the video, but a simpler solution (seems to me) was to update JQuery. Newer library doesn't send that header field.
